### PR TITLE
Issue #4: Adding configuration to be used by feign clients for either…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-feign</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.security.oauth</groupId>
 			<artifactId>spring-security-oauth2</artifactId>
 		</dependency>
@@ -146,6 +150,10 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.hateoas</groupId>
+			<artifactId>spring-hateoas</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>javax.inject</groupId>
@@ -166,6 +174,11 @@
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<version>3.1.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.netflix.feign</groupId>
+			<artifactId>feign-jackson</artifactId>
+			<version>8.18.0</version>
 		</dependency>
 
 		<!-- test dependencies-->

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/AbstractFeignConfiguration.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/AbstractFeignConfiguration.java
@@ -29,7 +29,6 @@ import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.hateoas.hal.Jackson2HalModule;
 
@@ -43,7 +42,6 @@ import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS
 public abstract class AbstractFeignConfiguration {
 
     @Bean
-    @ConditionalOnMissingBean(name = "feignObjectMapper")
     public ObjectMapper feignObjectMapper() {
         return new ObjectMapper()
                 .findAndRegisterModules()

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/AbstractFeignConfiguration.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/AbstractFeignConfiguration.java
@@ -1,0 +1,71 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-present IxorTalk CVBA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.ixortalk.autoconfigure.oauth2.feign;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import feign.Logger;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.hateoas.hal.Jackson2HalModule;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.ALL;
+import static com.fasterxml.jackson.annotation.PropertyAccessor.FIELD;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+
+public abstract class AbstractFeignConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(name = "feignObjectMapper")
+    public ObjectMapper feignObjectMapper() {
+        return new ObjectMapper()
+                .findAndRegisterModules()
+                .setVisibility(ALL, NONE)
+                .setVisibility(FIELD, ANY)
+                .configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .registerModule(new Jackson2HalModule())
+                .disable(WRITE_DATES_AS_TIMESTAMPS);
+    }
+
+    @Bean
+    Logger.Level feignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+
+    @Bean
+    public Decoder feignDecoder() {
+        return new JacksonDecoder(feignObjectMapper());
+    }
+
+    @Bean
+    public Encoder feignEncoder() {
+        return new JacksonEncoder(feignObjectMapper());
+    }
+}

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/OAuth2FeignRequestInterceptor.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/OAuth2FeignRequestInterceptor.java
@@ -1,0 +1,45 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-present IxorTalk CVBA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.ixortalk.autoconfigure.oauth2.feign;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+
+import static com.ixortalk.autoconfigure.oauth2.util.AuthTokenHelper.authorizationHeader;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+public class OAuth2FeignRequestInterceptor implements RequestInterceptor {
+
+    private OAuth2RestTemplate oAuth2RestTemplate;
+
+    public OAuth2FeignRequestInterceptor(OAuth2RestTemplate oAuth2RestTemplate) {
+        this.oAuth2RestTemplate = oAuth2RestTemplate;
+    }
+
+    @Override
+    public void apply(RequestTemplate template) {
+        template.header(AUTHORIZATION, authorizationHeader(oAuth2RestTemplate.getAccessToken()));
+    }
+}

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/ServiceToServiceFeignConfiguration.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/ServiceToServiceFeignConfiguration.java
@@ -1,0 +1,41 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-present IxorTalk CVBA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.ixortalk.autoconfigure.oauth2.feign;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.oauth2.client.OAuth2RestTemplate;
+
+import javax.inject.Inject;
+
+public class ServiceToServiceFeignConfiguration extends AbstractFeignConfiguration {
+
+    @Inject
+    private OAuth2RestTemplate oAuth2RestTemplate;
+
+    @Bean
+    public OAuth2FeignRequestInterceptor requestInterceptor() {
+        return new OAuth2FeignRequestInterceptor(oAuth2RestTemplate);
+    }
+}
+

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/TokenRelayFeignConfiguration.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/feign/TokenRelayFeignConfiguration.java
@@ -1,0 +1,44 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-present IxorTalk CVBA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.ixortalk.autoconfigure.oauth2.feign;
+
+import com.ixortalk.autoconfigure.oauth2.util.BearerTokenExtractor;
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+
+import javax.inject.Inject;
+
+import static com.ixortalk.autoconfigure.oauth2.util.AuthTokenHelper.authorizationHeader;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+public class TokenRelayFeignConfiguration extends AbstractFeignConfiguration {
+
+    @Inject
+    private BearerTokenExtractor bearerTokenExtractor;
+
+    @Bean
+    public RequestInterceptor requestInterceptor() {
+        return restTemplate -> restTemplate.header(AUTHORIZATION, authorizationHeader(bearerTokenExtractor.getBearerTokenValue()));
+    }
+}

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/util/AuthTokenHelper.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/util/AuthTokenHelper.java
@@ -1,0 +1,40 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-present IxorTalk CVBA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.ixortalk.autoconfigure.oauth2.util;
+
+import org.springframework.security.oauth2.common.OAuth2AccessToken;
+
+import static java.lang.String.format;
+import static org.springframework.security.oauth2.common.OAuth2AccessToken.BEARER_TYPE;
+
+public class AuthTokenHelper {
+
+    public static String authorizationHeader(OAuth2AccessToken oAuth2AccessToken) {
+        return authorizationHeader(oAuth2AccessToken.getValue());
+    }
+
+    public static String authorizationHeader(String accessToken) {
+        return format("%s %s", BEARER_TYPE, accessToken);
+    }
+}

--- a/src/main/java/com/ixortalk/autoconfigure/oauth2/util/BearerTokenExtractor.java
+++ b/src/main/java/com/ixortalk/autoconfigure/oauth2/util/BearerTokenExtractor.java
@@ -1,0 +1,29 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-present IxorTalk CVBA
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.ixortalk.autoconfigure.oauth2.util;
+
+public interface BearerTokenExtractor {
+
+    String getBearerTokenValue();
+}


### PR DESCRIPTION
… token relaying or service to service communication, extraction of bearer tokens and retrieval of client credentials token is properly configured to be either in Auth0 or plain OAuth2 context